### PR TITLE
Ensure master is an accurate record of cluster history

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -105,7 +105,7 @@ func deploy(req *model.DeploymentRequest) {
 		log.Fatalf("error updating status %v\n", err)
 	}
 
-	r, err := gh.GetRepo(req.CloneURL, req.Token)
+	r, err := gh.GetRepo(ctx, req.CloneURL, req.Token)
 	if err != nil {
 		log.Fatalf("error getting repo %v\n", err)
 	}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -1,25 +1,13 @@
 package agent
 
 import (
-	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
-	"os"
-	"path/filepath"
 	"strconv"
-	"strings"
 
-	"github.com/google/go-github/github"
 	"gopkg.in/go-playground/webhooks.v3"
 	webhook "gopkg.in/go-playground/webhooks.v3/github"
-	"gopkg.in/src-d/go-billy.v4"
-	git "gopkg.in/src-d/go-git.v4"
-	"gopkg.in/src-d/go-git.v4/plumbing"
 
-	"github.com/redbadger/deploy/filesystem"
-	gh "github.com/redbadger/deploy/github"
-	"github.com/redbadger/deploy/kubectl"
 	"github.com/redbadger/deploy/model"
 )
 
@@ -32,156 +20,6 @@ func Agent(port uint16, path, token, secret string) {
 	if err != nil {
 		log.Fatalln(fmt.Errorf("cannot listen for webhook: %v", err))
 	}
-}
-
-var patterns = []string{"*.yml", "*.yaml"}
-
-func visit(files *[]string) filesystem.WalkFunc {
-	return func(fs billy.Filesystem, path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return nil // can't walk here, but continue walking elsewhere
-		}
-		if info.IsDir() {
-			return nil // not a file.  ignore.
-		}
-		for _, pattern := range patterns {
-			matched, err := filepath.Match(pattern, info.Name())
-			if err != nil {
-				return err // malformed pattern, this is fatal.
-			}
-			if matched {
-				f, err := fs.Open(path)
-				if err != nil {
-					log.Fatalf("error opening file %v\n", err)
-				}
-				t, err := ioutil.ReadAll(f)
-				if err != nil {
-					log.Fatalf("cannot read file %v\n", err)
-				}
-				ts := string(t)
-				if !strings.HasSuffix(ts, "\n") {
-					ts += "\n"
-				}
-				*files = append(*files, ts)
-			}
-		}
-		return nil
-	}
-}
-
-func statusUpdater(
-	ctx context.Context, client *github.Client, context, login, repo, ref string,
-) func(state, desc string) error {
-	return func(state, desc string) error {
-		log.Printf("%s: %s", state, desc)
-		status := github.RepoStatus{
-			State:       &state,
-			Description: &desc,
-			Context:     &context,
-		}
-		_, _, err := client.Repositories.CreateStatus(ctx, login, repo, ref, &status)
-
-		if err != nil {
-			return fmt.Errorf("error updating status %v", err)
-		}
-		return nil
-	}
-}
-
-func deploy(req *model.DeploymentRequest) (err error) {
-	ctx := context.Background()
-	apiURL, err := APIRoot(req.URL)
-	if err != nil {
-		return
-	}
-	client, err := gh.NewClient(ctx, apiURL, req.Token)
-	if err != nil {
-		return
-	}
-
-	updateStatus := statusUpdater(
-		ctx, client, "deploy", req.Owner, req.Repo, req.HeadSHA,
-	)
-
-	err = updateStatus("pending", "deployment started")
-	if err != nil {
-		return
-	}
-
-	r, err := gh.GetRepo(ctx, req.CloneURL, req.Token)
-	if err != nil {
-		return fmt.Errorf("error getting repo %v", err)
-	}
-
-	// merge master
-	log.Println("merging master")
-	head := "master"
-	commit, _, err := client.Repositories.Merge(
-		ctx, req.Owner, req.Repo,
-		&github.RepositoryMergeRequest{
-			Base:          &req.HeadRef, // this PR HEAD
-			Head:          &head,
-			CommitMessage: nil,
-		})
-	if err != nil {
-		return fmt.Errorf("error merging master: %v", err)
-	}
-	if commit.SHA != nil {
-		// we merged master, so abandon this request after updating status
-		err = updateStatus(
-			"success",
-			fmt.Sprintf("master was merged so deployment will occur on commit %s", *commit.SHA),
-		)
-		return
-	}
-
-	w, err := r.Worktree()
-	if err != nil {
-		return fmt.Errorf("error getting work tree: %v", err)
-	}
-
-	err = w.Checkout(&git.CheckoutOptions{
-		Hash: plumbing.NewHash(req.HeadSHA),
-	})
-	if err != nil {
-		return fmt.Errorf("error checking out %s: %v", req.HeadSHA, err)
-	}
-
-	changedDirs, err := gh.GetChangedDirectories(r, req.HeadSHA, req.BaseSHA)
-	if err != nil {
-		return fmt.Errorf("error identifying changed top level directories: %v", err)
-	}
-
-	var succeeded []string
-	for _, dir := range changedDirs {
-		log.Printf("Walking %s\n", dir)
-		var contents []string
-		err = filesystem.Walk(w.Filesystem, dir, visit(&contents))
-		if err != nil {
-			return fmt.Errorf("error walking filesystem %v", err)
-		}
-		if len(contents) > 0 {
-			err = kubectl.Apply(dir, strings.Join(contents, "---\n"))
-			if err != nil {
-				err1 := updateStatus("error", fmt.Sprintf("deployment of %s failed: %v", dir, err))
-				if err1 != nil {
-					return
-				}
-			} else {
-				succeeded = append(succeeded, dir)
-			}
-		}
-	}
-	msg := fmt.Sprintf("deployment of %s succeeded", succeeded)
-	err1 := updateStatus("success", msg)
-	if err1 != nil {
-		return
-	}
-	_, _, err = client.PullRequests.Merge(ctx, req.Owner, req.Repo, int(req.Number), msg, nil)
-	if err != nil {
-		return
-	}
-	return
 }
 
 func consume(ch chan *model.DeploymentRequest) {

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -26,7 +26,7 @@ import (
 // Agent runs deploy as a bot
 func Agent(port uint16, path, token, secret string) {
 	hook := webhook.New(&webhook.Config{Secret: secret})
-	hook.RegisterEvents(handlePullRequest(token), webhook.PullRequestEvent)
+	hook.RegisterEvents(createPullRequestHandler(token), webhook.PullRequestEvent)
 
 	err := webhooks.Run(hook, ":"+strconv.FormatUint(uint64(port), 10), path)
 	if err != nil {
@@ -159,7 +159,7 @@ func consume(ch chan *model.DeploymentRequest) {
 	}
 }
 
-func handlePullRequest(token string) func(interface{}, webhooks.Header) {
+func createPullRequestHandler(token string) func(interface{}, webhooks.Header) {
 	ch := make(chan *model.DeploymentRequest, 100)
 	go consume(ch)
 	return func(payload interface{}, header webhooks.Header) {

--- a/agent/deploy.go
+++ b/agent/deploy.go
@@ -94,10 +94,7 @@ func deploy(req *model.DeploymentRequest) (err error) {
 		return
 	}
 
-	update := updater(
-		ctx, client, "deploy",
-		req.Owner, req.Repo, int(req.Number), req.HeadSHA,
-	)
+	update := updater(ctx, client, "deploy", req.Owner, req.Repo, int(req.Number), req.HeadSHA)
 
 	msg := "Deployment started!"
 	err = update("pending", msg, msg)
@@ -113,13 +110,12 @@ func deploy(req *model.DeploymentRequest) (err error) {
 	// merge master
 	log.Println("merging master")
 	head := "master"
-	commit, _, err := client.Repositories.Merge(
-		ctx, req.Owner, req.Repo,
-		&github.RepositoryMergeRequest{
-			Base:          &req.HeadRef, // this PR HEAD
-			Head:          &head,
-			CommitMessage: nil,
-		})
+	mergeReq := github.RepositoryMergeRequest{
+		Base:          &req.HeadRef, // this PR HEAD
+		Head:          &head,
+		CommitMessage: nil,
+	}
+	commit, _, err := client.Repositories.Merge(ctx, req.Owner, req.Repo, &mergeReq)
 	if err != nil {
 		return fmt.Errorf("error merging master: %v", err)
 	}

--- a/agent/deploy.go
+++ b/agent/deploy.go
@@ -1,0 +1,212 @@
+package agent
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/google/go-github/github"
+	"gopkg.in/src-d/go-billy.v4"
+	git "gopkg.in/src-d/go-git.v4"
+	"gopkg.in/src-d/go-git.v4/plumbing"
+
+	"github.com/redbadger/deploy/filesystem"
+	gh "github.com/redbadger/deploy/github"
+	"github.com/redbadger/deploy/kubectl"
+	"github.com/redbadger/deploy/model"
+)
+
+var patterns = []string{"*.yml", "*.yaml"}
+
+func visit(files *[]string) filesystem.WalkFunc {
+	return func(fs billy.Filesystem, path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil // can't walk here, but continue walking elsewhere
+		}
+		if info.IsDir() {
+			return nil // not a file.  ignore.
+		}
+		for _, pattern := range patterns {
+			matched, err := filepath.Match(pattern, info.Name())
+			if err != nil {
+				return err // malformed pattern, this is fatal.
+			}
+			if matched {
+				f, err := fs.Open(path)
+				if err != nil {
+					log.Fatalf("error opening file %v\n", err)
+				}
+				t, err := ioutil.ReadAll(f)
+				if err != nil {
+					log.Fatalf("cannot read file %v\n", err)
+				}
+				ts := string(t)
+				if !strings.HasSuffix(ts, "\n") {
+					ts += "\n"
+				}
+				*files = append(*files, ts)
+			}
+		}
+		return nil
+	}
+}
+
+func updater(
+	ctx context.Context, client *github.Client, context, owner, repo string, number int, ref string,
+) func(state, msg, comment string) (err error) {
+	return func(state, msg, comment string) (err error) {
+		log.Printf("%s: %s", state, msg)
+		status := github.RepoStatus{
+			State:       &state,
+			Description: &msg,
+			Context:     &context,
+		}
+		_, _, err = client.Repositories.CreateStatus(ctx, owner, repo, ref, &status)
+		if err != nil {
+			return fmt.Errorf("error updating status %v", err)
+		}
+
+		_, _, err = client.Issues.CreateComment(
+			ctx, owner, repo, number,
+			&github.IssueComment{Body: &comment},
+		)
+		if err != nil {
+			return fmt.Errorf("error creating comment %v", err)
+		}
+
+		return nil
+	}
+}
+
+func deploy(req *model.DeploymentRequest) (err error) {
+	ctx := context.Background()
+	apiURL, err := APIRoot(req.URL)
+	if err != nil {
+		return
+	}
+	client, err := gh.NewClient(ctx, apiURL, req.Token)
+	if err != nil {
+		return
+	}
+
+	update := updater(
+		ctx, client, "deploy",
+		req.Owner, req.Repo, int(req.Number), req.HeadSHA,
+	)
+
+	msg := "Deployment started!"
+	err = update("pending", msg, msg)
+	if err != nil {
+		return
+	}
+
+	r, err := gh.GetRepo(ctx, req.CloneURL, req.Token)
+	if err != nil {
+		return fmt.Errorf("error getting repo %v", err)
+	}
+
+	// merge master
+	log.Println("merging master")
+	head := "master"
+	commit, _, err := client.Repositories.Merge(
+		ctx, req.Owner, req.Repo,
+		&github.RepositoryMergeRequest{
+			Base:          &req.HeadRef, // this PR HEAD
+			Head:          &head,
+			CommitMessage: nil,
+		})
+	if err != nil {
+		return fmt.Errorf("error merging master: %v", err)
+	}
+	if commit.SHA != nil {
+		// we merged master, so abandon this request after updating status
+		msg := fmt.Sprintf("Master was merged so deployment will occur on commit %s", *commit.SHA)
+		err = update("success", msg, msg)
+		return
+	}
+
+	w, err := r.Worktree()
+	if err != nil {
+		return fmt.Errorf("error getting work tree: %v", err)
+	}
+
+	err = w.Checkout(&git.CheckoutOptions{
+		Hash: plumbing.NewHash(req.HeadSHA),
+	})
+	if err != nil {
+		return fmt.Errorf("error checking out %s: %v", req.HeadSHA, err)
+	}
+
+	changedDirs, err := gh.GetChangedDirectories(r, req.HeadSHA, req.BaseSHA)
+	if err != nil {
+		return fmt.Errorf("error identifying changed top level directories: %v", err)
+	}
+
+	succeeded := make(map[string]string)
+	for _, dir := range changedDirs {
+		log.Printf("Walking %s\n", dir)
+		var contents []string
+		err = filesystem.Walk(w.Filesystem, dir, visit(&contents))
+		if err != nil {
+			return fmt.Errorf("error walking filesystem %v", err)
+		}
+		if len(contents) > 0 {
+			out, err := apply(dir, strings.Join(contents, "---\n"))
+			if err != nil {
+				msg := fmt.Sprintf("deployment of %s failed: %v", dir, err)
+				comment := fmt.Sprintf("Deployment failed!\n%s", out)
+				err1 := update("error", msg, comment)
+				if err1 != nil {
+					return fmt.Errorf("%v\n%v", err, err1)
+				}
+				return err
+			}
+			succeeded[dir] = out
+		}
+	}
+	msg = fmt.Sprintf("deployment of %s succeeded", keys(succeeded))
+	comment := fmt.Sprintf("Deployment succeeded!\n%s", formatResults(succeeded))
+	err1 := update("success", msg, comment)
+	if err1 != nil {
+		return
+	}
+	_, _, err = client.PullRequests.Merge(ctx, req.Owner, req.Repo, int(req.Number), msg, nil)
+	if err != nil {
+		return
+	}
+	return
+}
+
+func apply(dir, manifest string) (out string, err error) {
+	out, err = kubectl.Apply(dir, manifest, true)
+	if err == nil {
+		out, err = kubectl.Apply(dir, manifest, false)
+	}
+	return
+}
+
+func keys(m map[string]string) (keys []string) {
+	keys = make([]string, len(m))
+
+	i := 0
+	for k := range m {
+		keys[i] = k
+		i++
+	}
+	return
+}
+
+var sub = regexp.MustCompile("\n")
+
+func formatResults(in map[string]string) (out string) {
+	out = ""
+	for k, v := range in {
+		out += fmt.Sprintf("* %s:\n\t%v\n\n", k, sub.ReplaceAllString(v, "\n\t"))
+	}
+	return
+}

--- a/agent/deploy.go
+++ b/agent/deploy.go
@@ -175,6 +175,10 @@ func deploy(req *model.DeploymentRequest) (err error) {
 	if err != nil {
 		return
 	}
+	_, err = client.Git.DeleteRef(ctx, req.Owner, req.Repo, fmt.Sprintf("heads/%s", req.HeadRef))
+	if err != nil {
+		return
+	}
 	return
 }
 

--- a/agent/deploy.go
+++ b/agent/deploy.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/google/go-github/github"
@@ -198,6 +199,7 @@ func keys(m map[string]string) (keys []string) {
 		keys[i] = k
 		i++
 	}
+	sort.Strings(keys)
 	return
 }
 
@@ -205,8 +207,8 @@ var sub = regexp.MustCompile("\n")
 
 func formatResults(in map[string]string) (out string) {
 	out = ""
-	for k, v := range in {
-		out += fmt.Sprintf("* %s:\n\t%v\n\n", k, sub.ReplaceAllString(v, "\n\t"))
+	for _, k := range keys(in) {
+		out += fmt.Sprintf("* %s:\n\t%v\n\n", k, sub.ReplaceAllString(in[k], "\n\t"))
 	}
 	return
 }

--- a/agent/deploy_test.go
+++ b/agent/deploy_test.go
@@ -1,6 +1,9 @@
 package agent
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func Test_formatResults(t *testing.T) {
 	type args struct {
@@ -21,7 +24,7 @@ func Test_formatResults(t *testing.T) {
 		{
 			"two keys",
 			args{
-				map[string]string{"one": "test1", "two": "test2"},
+				map[string]string{"two": "test2", "one": "test1"},
 			},
 			"* one:\n\ttest1\n\n* two:\n\ttest2\n\n",
 		},
@@ -37,6 +40,33 @@ func Test_formatResults(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if gotOut := formatResults(tt.args.in); gotOut != tt.wantOut {
 				t.Errorf("formatResults() = %v, want %v", gotOut, tt.wantOut)
+			}
+		})
+	}
+}
+
+func Test_keys(t *testing.T) {
+	type args struct {
+		m map[string]string
+	}
+	tests := []struct {
+		name     string
+		args     args
+		wantKeys []string
+	}{
+		{
+			"gets sorted keys",
+			args{
+				map[string]string{"b": "2", "a": "1"},
+			},
+			[]string{"a", "b"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotKeys := keys(tt.args.m); !reflect.DeepEqual(gotKeys, tt.wantKeys) {
+				t.Errorf("keys() = %v, want %v", gotKeys, tt.wantKeys)
 			}
 		})
 	}

--- a/agent/deploy_test.go
+++ b/agent/deploy_test.go
@@ -1,0 +1,43 @@
+package agent
+
+import "testing"
+
+func Test_formatResults(t *testing.T) {
+	type args struct {
+		in map[string]string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantOut string
+	}{
+		{
+			"one key",
+			args{
+				map[string]string{"one": "test"},
+			},
+			"* one:\n\ttest\n\n",
+		},
+		{
+			"two keys",
+			args{
+				map[string]string{"one": "test1", "two": "test2"},
+			},
+			"* one:\n\ttest1\n\n* two:\n\ttest2\n\n",
+		},
+		{
+			"two key multiline",
+			args{
+				map[string]string{"one": "test1a\ntest1b", "two": "test2a\ntest2b"},
+			},
+			"* one:\n\ttest1a\n\ttest1b\n\n* two:\n\ttest2a\n\ttest2b\n\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotOut := formatResults(tt.args.in); gotOut != tt.wantOut {
+				t.Errorf("formatResults() = %v, want %v", gotOut, tt.wantOut)
+			}
+		})
+	}
+}

--- a/github/getRepo.go
+++ b/github/getRepo.go
@@ -12,7 +12,7 @@ import (
 )
 
 // GetRepo returns a git Repository cloned into a new in-memory filesystem
-func GetRepo(cloneURL, org, name, token, headRef, baseRef string) (r *git.Repository, err error) {
+func GetRepo(cloneURL, token string) (r *git.Repository, err error) {
 	context := context.Background()
 	r, err = git.CloneContext(context, memory.NewStorage(), memfs.New(), &git.CloneOptions{
 		URL:  cloneURL,

--- a/github/getRepo.go
+++ b/github/getRepo.go
@@ -12,9 +12,8 @@ import (
 )
 
 // GetRepo returns a git Repository cloned into a new in-memory filesystem
-func GetRepo(cloneURL, token string) (r *git.Repository, err error) {
-	context := context.Background()
-	r, err = git.CloneContext(context, memory.NewStorage(), memfs.New(), &git.CloneOptions{
+func GetRepo(ctx context.Context, cloneURL, token string) (r *git.Repository, err error) {
+	r, err = git.CloneContext(ctx, memory.NewStorage(), memfs.New(), &git.CloneOptions{
 		URL:  cloneURL,
 		Auth: &gHttp.BasicAuth{Username: "none", Password: token},
 	})

--- a/kubectl/apply.go
+++ b/kubectl/apply.go
@@ -8,16 +8,18 @@ import (
 )
 
 // Apply passes the supplied manifests to the stdin of `kubectl apply -f -`
-func Apply(namespace, manifests string) (err error) {
-	cmd := exec.Command("kubectl", "--namespace", namespace, "apply", "-f", "-")
+func Apply(namespace, manifests string, isDryRun bool) (output string, err error) {
+	var args = []string{"--namespace", namespace, "apply", "-f", "-"}
+	if isDryRun {
+		args = append(args, "--dry-run")
+	}
+	cmd := exec.Command("kubectl", args...)
 	cmd.Env = os.Environ()
 	cmd.Stdin = strings.NewReader(manifests)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	err = cmd.Run()
+	out, err := cmd.CombinedOutput()
+	output = string(out)
 	if err != nil {
-		err = fmt.Errorf("Cannot run kubectl: %v", err)
-		return
+		return output, fmt.Errorf("Cannot run kubectl: %v", err)
 	}
 	return
 }

--- a/model/model.go
+++ b/model/model.go
@@ -1,0 +1,19 @@
+package model
+
+// The DeploymentRequest type carries all the information needed to request a deployment
+type DeploymentRequest struct {
+	// URL is the repository URL
+	URL string
+	// CloneURL is the URL used to clone the repo
+	CloneURL string
+	// Token is the user's github Personal Access Token
+	Token string
+	// The repo owner
+	Owner string
+	// the repo name
+	Repo string
+	// the SHA of the HEAD
+	HeadRef string
+	// the SHA of the BASE
+	BaseRef string
+}

--- a/model/model.go
+++ b/model/model.go
@@ -12,8 +12,10 @@ type DeploymentRequest struct {
 	Owner string
 	// the repo name
 	Repo string
-	// the SHA of the HEAD
+	// the Branch name of the HEAD
 	HeadRef string
+	// the SHA of the HEAD
+	HeadSHA string
 	// the SHA of the BASE
-	BaseRef string
+	BaseSHA string
 }

--- a/model/model.go
+++ b/model/model.go
@@ -12,6 +12,8 @@ type DeploymentRequest struct {
 	Owner string
 	// the repo name
 	Repo string
+	// PR Number
+	Number int64
 	// the Branch name of the HEAD
 	HeadRef string
 	// the SHA of the HEAD

--- a/request/request.go
+++ b/request/request.go
@@ -28,7 +28,8 @@ func buildCloneURL(githubURL, org, repo string) string {
 // Request raises a PR against the deploy repo with the configuration to be deployed
 func Request(stacksDir, project, sha, githubURL, apiURL, org, repo, token string) {
 	// Create in-mem FS w/ cloned deployments repo
-	r, err := gh.GetRepo(buildCloneURL(githubURL, org, repo), token)
+	ctx := context.Background()
+	r, err := gh.GetRepo(ctx, buildCloneURL(githubURL, org, repo), token)
 	if err != nil {
 		log.Fatalln(err) // err has enough info
 	}
@@ -114,14 +115,14 @@ func Request(stacksDir, project, sha, githubURL, apiURL, org, repo, token string
 	}
 
 	// Raise PR ["deployments" repo] with requested changes
-	client, err := gh.NewClient(context.Background(), apiURL, token)
+	client, err := gh.NewClient(ctx, apiURL, token)
 
 	title := project + " deployment request"
 	head := branchName
 	base := "master"
 	body := "Deployment request for " + project + " at " + sha
 
-	pr, _, err := client.PullRequests.Create(context.Background(), org, repo, &github.NewPullRequest{
+	pr, _, err := client.PullRequests.Create(ctx, org, repo, &github.NewPullRequest{
 		Title: &title,
 		Head:  &head,
 		Base:  &base,

--- a/request/request.go
+++ b/request/request.go
@@ -28,8 +28,7 @@ func buildCloneURL(githubURL, org, repo string) string {
 // Request raises a PR against the deploy repo with the configuration to be deployed
 func Request(stacksDir, project, sha, githubURL, apiURL, org, repo, token string) {
 	// Create in-mem FS w/ cloned deployments repo
-	cloneURL := buildCloneURL(githubURL, org, repo)
-	r, err := gh.GetRepo(cloneURL, org, repo, token, "master", "master")
+	r, err := gh.GetRepo(buildCloneURL(githubURL, org, repo), token)
 	if err != nil {
 		log.Fatalln(err) // err has enough info
 	}

--- a/request/request.go
+++ b/request/request.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"context"
+	"fmt"
 	"log"
 	"net/url"
 	"path"
@@ -82,7 +83,7 @@ func Request(stacksDir, project, sha, githubURL, apiURL, org, repo, token string
 	}
 
 	// git commit
-	commit, err := w.Commit("Commit message!", &git.CommitOptions{
+	commit, err := w.Commit(fmt.Sprintf("%s at %s", project, sha), &git.CommitOptions{
 		Author: &object.Signature{
 			Name:  "Robot",
 			Email: "robot",


### PR DESCRIPTION
issue #8 

- [x] commits on master can only be made if the deployment they describe succeeded.
- [x] agent must process requests one at a time, in the order in which they were raised (therefore we need a queue in the agent). This also means that only one replica of the agent pod can be running (and we will need to address high availability at a later stage).
- [x] to mitigate the situation where multiple requests are raised simultaneously (or more accurately where a second request is raised before the previous one is completed), it is necessary to merge master into the PR branch and do a dry-run, and then either deploy on success or close on failure. The merge to master is then guaranteed.