### PR TITLE
Namespaced requests

### DIFF
--- a/agent/deploy.go
+++ b/agent/deploy.go
@@ -158,7 +158,7 @@ func deploy(req *model.DeploymentRequest) (err error) {
 			return fmt.Errorf("error walking filesystem %v", err)
 		}
 		if len(contents) > 0 {
-			manifests := joinManifests(contents, dir)
+			manifests := joinManifests(dir, contents)
 			out, err := apply(dir, manifests)
 			if err != nil {
 				msg := fmt.Sprintf("deployment of %s failed: %v", dir, err)
@@ -192,7 +192,7 @@ func deploy(req *model.DeploymentRequest) (err error) {
 // By prepending a default namespace template we will loose any metadata
 // on existing namespaces. We need to find a solution to this when it
 // becomes a problem.
-func joinManifests(manifests []string, namespace string) string {
+func joinManifests(namespace string, manifests []string) string {
 	namespaceManifest := fmt.Sprintf(namespaceTemplate, namespace)
 	manifests = append([]string{namespaceManifest}, manifests...)
 	return strings.Join(manifests, "\n---\n")

--- a/agent/deploy_test.go
+++ b/agent/deploy_test.go
@@ -71,3 +71,39 @@ func Test_keys(t *testing.T) {
 		})
 	}
 }
+
+func Test_joinManifests(t *testing.T) {
+	type args struct {
+		manifests []string
+		namespace string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			"joins manifests and puts namespace manifest in front",
+			args{
+				[]string{"a\n", "b\n"},
+				"my-namespace",
+			},
+			"---\napiVersion: 1\nkind: Namespace\nmetadata:\n  name: my-namespace\n---\na\n\n---\nb\n",
+		},
+		{
+			"manifests don't have final newlines",
+			args{
+				[]string{"a", "b"},
+				"my-namespace",
+			},
+			"---\napiVersion: 1\nkind: Namespace\nmetadata:\n  name: my-namespace\n---\na\n---\nb",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := joinManifests(tt.args.manifests, tt.args.namespace); got != tt.want {
+				t.Errorf("joinManifests() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/agent/deploy_test.go
+++ b/agent/deploy_test.go
@@ -74,8 +74,8 @@ func Test_keys(t *testing.T) {
 
 func Test_joinManifests(t *testing.T) {
 	type args struct {
-		manifests []string
 		namespace string
+		manifests []string
 	}
 	tests := []struct {
 		name string
@@ -85,23 +85,23 @@ func Test_joinManifests(t *testing.T) {
 		{
 			"joins manifests and puts namespace manifest in front",
 			args{
-				[]string{"a\n", "b\n"},
 				"my-namespace",
+				[]string{"a\n", "b\n"},
 			},
 			"---\napiVersion: 1\nkind: Namespace\nmetadata:\n  name: my-namespace\n---\na\n\n---\nb\n",
 		},
 		{
 			"manifests don't have final newlines",
 			args{
-				[]string{"a", "b"},
 				"my-namespace",
+				[]string{"a", "b"},
 			},
 			"---\napiVersion: 1\nkind: Namespace\nmetadata:\n  name: my-namespace\n---\na\n---\nb",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := joinManifests(tt.args.manifests, tt.args.namespace); got != tt.want {
+			if got := joinManifests(tt.args.namespace, tt.args.manifests); got != tt.want {
 				t.Errorf("joinManifests() = %v, want %v", got, tt.want)
 			}
 		})

--- a/cmd/request.go
+++ b/cmd/request.go
@@ -10,13 +10,13 @@ import (
 )
 
 var (
-	stacksDir string
-	project   string
-	sha       string
-	githubURL string
-	apiURL    string
-	org       string
-	repo      string
+	namespace   string
+	manifestDir string
+	sha         string
+	githubURL   string
+	apiURL      string
+	org         string
+	repo        string
 )
 
 var requestCmd = &cobra.Command{
@@ -30,7 +30,7 @@ Raise a PR against the cluster repo with the configuration to be deployed:
 2. copies the specified manifests into a new branch
 3. commits, pushes and raises a PR requesting deployment
 	`,
-	Example: `deploy request --stacksDir=example --project=guestbook --sha=41e8650 --org=redbadger --repo=cluster-local`,
+	Example: `deploy request --namespace=guestbook --manifestDir=example/guestbook --sha=41e8650 --org=redbadger --repo=cluster-local`,
 	PreRun: func(cmd *cobra.Command, args []string) {
 		if !viper.IsSet(constants.TokenEnvVar) {
 			log.Fatalf("environment variable %s is not exported.\n", constants.TokenEnvVar)
@@ -38,16 +38,16 @@ Raise a PR against the cluster repo with the configuration to be deployed:
 		token = viper.GetString(constants.TokenEnvVar)
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		request.Request(stacksDir, project, sha, githubURL, apiURL, org, repo, token)
+		request.Request(namespace, manifestDir, sha, githubURL, apiURL, org, repo, token)
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(requestCmd)
-	requestCmd.Flags().StringVar(&stacksDir, "stacksDir", "stacks", "Name of stacks directory")
+	requestCmd.Flags().StringVar(&namespace, "namespace", "", "Namespace")
+	requestCmd.MarkFlagRequired("namespace")
 
-	requestCmd.Flags().StringVar(&project, "project", "", "Project name")
-	requestCmd.MarkFlagRequired("project")
+	requestCmd.Flags().StringVar(&manifestDir, "manifestDir", ".", "Location of kubernetes manifest files")
 
 	requestCmd.Flags().StringVar(&sha, "sha", "", "Commit SHA")
 	requestCmd.MarkFlagRequired("sha")

--- a/readme.md
+++ b/readme.md
@@ -96,7 +96,7 @@ service "guestbook-ui" created
 `deploy request` runs in the CD pipeline, but you can test from the root directory of this repo. Modify the config in `/example/guestbook` and then:
 
 ```
-> deploy request --stacksDir=example --project=guestbook --sha=41e8650 --org=redbadger --repo=cluster-local
+> deploy request --namespace=guestbook --manifestDir=example/guestbook --sha=41e8650 --org=redbadger --repo=cluster-local
 2018/03/17 13:50:22 copying from example/guestbook to /guestbook
 2018/03/17 13:50:22 commit obj: commit cfb3da3c0b28f4bb731a13689ed0f994ba24b340
 Author: Robot <robot>


### PR DESCRIPTION
This adds changes to make it possible to deploy the same stack into many namespaces.

The directory name in the cluster repository corresponds to the namespace. Resources currently should not have a namespace declaration in their manifest.

Changes are:
* Use options `--namespace` and `--manifestDir` instead of `--project` and `--stacksDir` in `deploy request`.
* Make `deploy agent` automatically create the namespace with the name of the directory.