### PR TITLE
Fix apiVersion in namespace template

### DIFF
--- a/agent/deploy.go
+++ b/agent/deploy.go
@@ -24,7 +24,7 @@ import (
 
 var patterns = []string{"*.yml", "*.yaml"}
 var namespaceTemplate = `---
-apiVersion: 1
+apiVersion: v1
 kind: Namespace
 metadata:
   name: %s`

--- a/agent/deploy_test.go
+++ b/agent/deploy_test.go
@@ -88,7 +88,7 @@ func Test_joinManifests(t *testing.T) {
 				"my-namespace",
 				[]string{"a\n", "b\n"},
 			},
-			"---\napiVersion: 1\nkind: Namespace\nmetadata:\n  name: my-namespace\n---\na\n\n---\nb\n",
+			"---\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: my-namespace\n---\na\n\n---\nb\n",
 		},
 		{
 			"manifests don't have final newlines",
@@ -96,7 +96,7 @@ func Test_joinManifests(t *testing.T) {
 				"my-namespace",
 				[]string{"a", "b"},
 			},
-			"---\napiVersion: 1\nkind: Namespace\nmetadata:\n  name: my-namespace\n---\na\n---\nb",
+			"---\napiVersion: v1\nkind: Namespace\nmetadata:\n  name: my-namespace\n---\na\n---\nb",
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
`apiVersion` in the namespace template needs to be a string.