### PR TITLE
Fork git commands (rather than use git-go)

### DIFF
--- a/request/copy.go
+++ b/request/copy.go
@@ -1,0 +1,69 @@
+package request
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path"
+)
+
+// copyFile copies a single file from src to dst
+func copyFile(src, dst string) error {
+	var err error
+	var srcfd *os.File
+	var dstfd *os.File
+	var srcinfo os.FileInfo
+
+	if srcfd, err = os.Open(src); err != nil {
+		return err
+	}
+	defer srcfd.Close()
+
+	if dstfd, err = os.Create(dst); err != nil {
+		return err
+	}
+	defer dstfd.Close()
+
+	if _, err = io.Copy(dstfd, srcfd); err != nil {
+		return err
+	}
+	if srcinfo, err = os.Stat(src); err != nil {
+		return err
+	}
+	return os.Chmod(dst, srcinfo.Mode())
+}
+
+// copyDir copies a whole directory recursively
+func copyDir(src string, dst string) error {
+	var err error
+	var fds []os.FileInfo
+	var srcinfo os.FileInfo
+
+	if srcinfo, err = os.Stat(src); err != nil {
+		return err
+	}
+
+	if err = os.MkdirAll(dst, srcinfo.Mode()); err != nil {
+		return err
+	}
+
+	if fds, err = ioutil.ReadDir(src); err != nil {
+		return err
+	}
+	for _, fd := range fds {
+		srcfp := path.Join(src, fd.Name())
+		dstfp := path.Join(dst, fd.Name())
+
+		if fd.IsDir() {
+			if err = copyDir(srcfp, dstfp); err != nil {
+				fmt.Println(err)
+			}
+		} else {
+			if err = copyFile(srcfp, dstfp); err != nil {
+				fmt.Println(err)
+			}
+		}
+	}
+	return nil
+}

--- a/request/request.go
+++ b/request/request.go
@@ -122,8 +122,5 @@ func git(workingDir string, args ...string) (err error) {
 	cmd.Env = os.Environ()
 	cmd.Dir = workingDir
 	err = cmd.Run()
-	if err != nil {
-		log.WithError(err).Error("executing git with args: %s", args)
-	}
 	return
 }

--- a/request/request.go
+++ b/request/request.go
@@ -82,6 +82,7 @@ func Request(namespace, manifestDir, sha, githubURL, apiURL, org, repo, token st
 	err = git(srcDir, "commit",
 		"--message", fmt.Sprintf("%s at %s", namespace, sha),
 		"--author", "Robot <robot>",
+		"--allow-empty",
 	)
 	if err != nil {
 		log.WithError(err).Fatal("commit")


### PR DESCRIPTION
We found a few problems with removing/renaming old files when using `go-git.v4`.

We now defer to the `git` cli command instead, as we trust its behaviour and it is much more familiar to everyone.