### PR TITLE
don't fail git rm when files don't exist

### DIFF
--- a/request/request.go
+++ b/request/request.go
@@ -57,7 +57,7 @@ func Request(namespace, manifestDir, sha, githubURL, apiURL, org, repo, token st
 		srcDir,
 	)
 	git(srcDir, "checkout", "-b", branchName)
-	git(srcDir, "rm", "-r", namespace)
+	git(srcDir, "rm", "-r", "--ignore-unmatch", namespace)
 
 	err = copyDir(manifestDir, path.Join(srcDir, namespace))
 	if err != nil {


### PR DESCRIPTION
Currently during `deploy request` we try to `git rm` the branch before we add the new files back. This would fail if the files don't exist (e.g. first deploy). This PR fixes that.