### PR TITLE
dockerfile for go 1.11.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,27 @@
 #~~~~~~~~~~~~~~~~~~~~~~~
-FROM golang:1.10-alpine as builder
+FROM golang:1.11.2-alpine3.8 as builder
 RUN apk --no-cache add \
-    git \
-    curl
+  git \
+  curl
 
-WORKDIR /go/src/github.com/redbadger/deploy
+WORKDIR /src
 COPY . .
 RUN go get -d ./...
 RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o deploy .
 
-ENV KUBE_LATEST_VERSION="v1.9.5"
+ENV KUBE_LATEST_VERSION="v1.12.3"
 RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
- && chmod +x /usr/local/bin/kubectl
+  && chmod +x /usr/local/bin/kubectl
 
 #~~~~~~~~~~~~~~~~~~~~~~~
-FROM alpine:latest
-RUN apk --no-cache add ca-certificates
+FROM alpine:3.8
+RUN apk --no-cache add \
+  ca-certificates \
+  git \
+  ;
 
 WORKDIR /root/
 COPY --from=builder /usr/local/bin/kubectl /usr/local/bin
-COPY --from=builder /go/src/github.com/redbadger/deploy/deploy .
+COPY --from=builder /src/deploy .
 ENTRYPOINT ["./deploy"]
 CMD ["help"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONEY: default
+default:
+	docker build -t redbadger/deploy .
+	docker push redbadger/deploy


### PR DESCRIPTION
Updates `Dockerfile` for go greater than v1.11.1 which is needed for go modules